### PR TITLE
chore: migrate repo references to mavogel/cdk-hugo-pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,5 +128,5 @@ jobs:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
           NPM_CONFIG_PROVENANCE: "true"
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -9,7 +9,8 @@ const project = new MvcCdkConstructLibrary({
   jsiiVersion: '~5.9.0',
   name: 'cdk-hugo-pipeline',
   projenrcTs: true,
-  repositoryUrl: 'https://github.com/MV-Consulting/cdk-hugo-pipeline',
+  npmTrustedPublishing: true,
+  repositoryUrl: 'https://github.com/mavogel/cdk-hugo-pipeline',
 
   deps: [
     '@mavogel/mvc-projen@0.0.25',

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # cdk-hugo-pipeline
-![Source](https://img.shields.io/github/stars/MV-Consulting/cdk-hugo-pipeline?logo=github&label=GitHub%20Stars)
-[![Build Status](https://github.com/MV-Consulting/cdk-hugo-pipeline/actions/workflows/build.yml/badge.svg)](https://github.com/MV-Consulting/cdk-hugo-pipeline/actions/workflows/build.yml)
+![Source](https://img.shields.io/github/stars/mavogel/cdk-hugo-pipeline?logo=github&label=GitHub%20Stars)
+[![Build Status](https://github.com/mavogel/cdk-hugo-pipeline/actions/workflows/build.yml/badge.svg)](https://github.com/mavogel/cdk-hugo-pipeline/actions/workflows/build.yml)
 [![ESLint Code Formatting](https://img.shields.io/badge/code_style-eslint-brightgreen.svg)](https://eslint.org)
-[![Latest release](https://img.shields.io/github/release/MV-Consulting/cdk-hugo-pipeline.svg)](https://github.com/MV-Consulting/cdk-hugo-pipeline/releases)
-![GitHub](https://img.shields.io/github/license/MV-Consulting/cdk-hugo-pipeline)
+[![Latest release](https://img.shields.io/github/release/mavogel/cdk-hugo-pipeline.svg)](https://github.com/mavogel/cdk-hugo-pipeline/releases)
+![GitHub](https://img.shields.io/github/license/mavogel/cdk-hugo-pipeline)
 [![npm](https://img.shields.io/npm/dt/@mavogel/cdk-hugo-pipeline?label=npm&color=orange)](https://www.npmjs.com/package/@mavogel/cdk-hugo-pipeline)
 [![typescript](https://img.shields.io/badge/jsii-typescript-blueviolet.svg)](https://www.npmjs.com/package/@mavogel/cdk-hugo-pipeline)
 [![cdk-constructs: experimental](https://img.shields.io/badge/cdk--constructs-experimental-yellow.svg)](https://constructs.dev/packages/@mavogel/cdk-hugo-pipeline)
@@ -130,7 +130,7 @@ export class MyStack extends Stack {
     });
 }
 ```
-and adapt the `main.test.ts` (yes, known issue. See [#40](https://github.com/MV-Consulting/cdk-hugo-pipeline/issues/40))
+and adapt the `main.test.ts` (yes, known issue. See [#40](https://github.com/mavogel/cdk-hugo-pipeline/issues/40))
 
 ```ts
 test('Snapshot', () => {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Build you hugo website all on AWS with CI/CD and a dev environment.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MV-Consulting/cdk-hugo-pipeline"
+    "url": "https://github.com/mavogel/cdk-hugo-pipeline"
   },
   "scripts": {
     "build": "projen build",


### PR DESCRIPTION
## Summary
- Update repository URL/references (README badges, package.json, .projenrc.ts) from `MV-Consulting/cdk-hugo-pipeline` to `mavogel/cdk-hugo-pipeline`
- Enable npm trusted publishing in the release workflow, replacing the `NPM_TOKEN` secret with `NPM_TRUSTED_PUBLISHER`

## Test plan
- `npm run projen` regenerates clean (no drift)
- `npm run eslint` passes